### PR TITLE
Ipv6 evpn

### DIFF
--- a/EVPN/ibgp-ebgp/ipv6-evpn/README.txt
+++ b/EVPN/ibgp-ebgp/ipv6-evpn/README.txt
@@ -1,0 +1,10 @@
+This is a leaf-spine topology that uses Arista's iBGP over eBGP model of 
+running EVPN. It utilizes a dual-stack throughout, and runs VXLAN with an
+IPv6 header, and IPv4 packets are carried encapsulated by this IPv6 VXLAN
+as well. 
+
+We also have a dcedge node that runs in a different VRF and we leak routes
+between the evpn vrf and the internet vrf. I should've added a firewall node
+as well, but lacked the time.
+
+The specific route maps and such may make this workable only with EOS for now.

--- a/EVPN/ibgp-ebgp/ipv6-evpn/eos-activate-evpn.j2
+++ b/EVPN/ibgp-ebgp/ipv6-evpn/eos-activate-evpn.j2
@@ -1,0 +1,13 @@
+!
+! Activate EVPN AF for IPv6 iBGP neighbors on EOS
+!
+{% if bgp is defined and bgp.neighbors is defined %}
+router bgp {{ bgp.as }}
+{%   for n in bgp.neighbors if n.type == 'ibgp' and n.ipv6 is defined %}
+   address-family evpn
+      neighbor {{ n.ipv6 }} activate
+{%   endfor %}
+int Vxlan 1
+    vxlan encapsulation ipv6
+exit
+{% endif %}

--- a/EVPN/ibgp-ebgp/ipv6-evpn/route-map.j2
+++ b/EVPN/ibgp-ebgp/ipv6-evpn/route-map.j2
@@ -1,0 +1,43 @@
+! IPv6 prefix-list - match prefixes /64 or shorter (less specific)
+ipv6 prefix-list IPV6-LEAK-FILTER
+  seq 10 permit ::/0 le 64
+exit
+
+! IPv4 prefix-list - match prefixes /24 or shorter (less specific)
+ip prefix-list IPV4-LEAK-FILTER
+  seq 10 permit 0.0.0.0/0 le 24
+exit
+
+! Route-map to apply both filters
+route-map LEAK-BY-PREFIX-LENGTH permit 10
+   match ip address prefix-list IPV4-LEAK-FILTER
+!
+route-map LEAK-BY-PREFIX-LENGTH permit 20
+   match ipv6 address prefix-list IPV6-LEAK-FILTER
+!
+route-map LEAK-BY-PREFIX-LENGTH deny 30
+route-map ACCEPT_INTERNET_ROUTES permit 10
+! For some reason, netlab makes tenant vrf as not routed on exits
+ipv6 unicast-routing vrf tenant
+
+{% if bgp is defined and bgp.neighbors is defined %}
+router bgp {{ bgp.as }}
+  vrf tenant
+     address-family ipv4 
+       redistribute bgp leaked
+     address-family ipv6
+       redistribute connected
+       redistribute bgp leaked
+  vrf internet
+     address-family ipv4
+       redistribute connected  
+       redistribute bgp leaked
+     address-family ipv6
+       redistribute connected  
+       redistribute bgp leaked
+{% endif %}
+router general
+  vrf tenant
+     leak routes source-vrf internet subscribe-policy ACCEPT_INTERNET_ROUTES
+  vrf internet
+     leak routes source-vrf tenant subscribe-policy LEAK-BY-PREFIX-LENGTH

--- a/EVPN/ibgp-ebgp/ipv6-evpn/topology.yml
+++ b/EVPN/ibgp-ebgp/ipv6-evpn/topology.yml
@@ -1,0 +1,232 @@
+---
+defaults.device: eos
+provider: libvirt
+plugin: [ fabric, multilab ]
+defaults.multilab.id: 31
+bgp:
+  as: 65000
+  #bgp.activate.ipv4: [ ebgp ]                     # Activate IPv4 only on EBGP sessions
+  activate:
+     ipv6: [ ebgp ]                     # Activate IPv6 only on EBGP sessions
+  sessions: 
+     ipv6: [ ebgp, ibgp ]
+defaults.bgp.warnings.missing_igp: False        # Skip the "you probably need an IGP" warnings
+
+# Both IPv4 and IPv6 pools are defined.
+# Underlay uses IPv4; IPv6 is used for tenant addressing and optional loopbacks and bgp sessions.
+addressing:
+  loopback:
+    ipv4: 10.0.0.0/24
+    ipv6: 2001:db8:0::/48
+  p2p:
+    ipv4: 10.1.0.0/16
+    ipv6: 2001:db8:1::/48
+
+groups:
+  _auto_create: True
+  leafs:
+    members: [ roma-leaf01, roma-leaf02, roma-leaf03, roma-leaf04 ]
+    module: [ bgp, vlan, vxlan, evpn, vrf, lag, gateway ]
+    config: [ eos-activate-evpn.j2 ]
+    
+  spines:
+    members: [ roma-spine01, roma-spine02 ]
+    module: [ bgp, evpn ]
+    bgp.rr: True
+    config: [ eos-activate-evpn.j2 ]
+
+  exits:
+    members: [ roma-exit01, roma-exit02 ]
+    module: [ bgp, vxlan, vlan, vrf, evpn ]
+    config: [ eos-activate-evpn.j2, route-map.j2 ]
+    vrfs:
+      tenant:
+        loopback: true
+      internet:
+        loopback: true
+
+  dcedge:
+    members: [ roma-dcedge01 ]
+    module: [ bgp ]
+    
+  hosts:
+    members: [ srv101, srv102, srv201, srv202 ]
+    module: [ lag ]
+    device: linux
+
+vlan.mode: irb                                   # Enable routing between VLANs
+
+vrfs:
+  tenant:
+    id: 50000
+    evpn:
+      transit_vni: 50000
+    bgp: False
+
+  internet:
+
+    
+vlans:
+  red:
+    vrf: tenant                                  # Assign to VRF
+    prefix.ipv4: 172.16.10.0/24                   # IPv4 subnet
+    prefix.ipv6: 2001:db8:10::/64
+    gateway: true                                # Enable gateway on this VLAN
+
+  blue:
+    vrf: tenant                                  # Assign to VRF
+    prefix.ipv4: 172.16.20.0/24                   # IPv4 subnet
+    prefix.ipv6: 2001:db8:20::/64
+    gateway: true                                # Enable gateway on this VLAN
+
+  cyan:
+    vrf: tenant                                  # Assign to VRF
+    prefix.ipv4: 172.16.30.0/24                   # IPv4 subnet
+    prefix.ipv6: 2001:db8:30::/64
+    gateway: true                                # Enable gateway on this VLAN
+
+nodes:
+  roma-dcedge01:
+    bgp:
+      as: 65534
+
+links:
+
+# Loopbacks for VTEP for leaves and exits
+- roma-leaf01:
+    type: loopback
+    ipv6: 2001:db8:2::12/128
+    vxlan.vtep: true
+- roma-leaf02:
+    type: loopback
+    ipv6: 2001:db8:2::12/128
+    vxlan.vtep: true
+- roma-leaf03:
+    type: loopback
+    ipv6: 2001:db8:2::34/128
+    vxlan.vtep: true
+- roma-leaf04:
+    type: loopback
+    ipv6: 2001:db8:2::34/128
+    vxlan.vtep: true
+    
+- roma-exit01:
+    type: loopback
+    ipv6: 2001:db8:2::101/128
+    vxlan.vtep: true
+    
+- roma-exit02:
+    type: loopback
+    ipv6: 2001:db8:2::101/128
+    vxlan.vtep: true
+
+# Fabric Links, with as
+- roma-leaf01:
+    bgp.local_as: 65101
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-leaf01:
+    bgp.local_as: 65101
+  roma-spine02:
+    bgp.local_as: 65200
+- roma-leaf02:
+    bgp.local_as: 65102
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-leaf02:
+    bgp.local_as: 65102
+  roma-spine02:
+    bgp.local_as: 65200
+- roma-leaf03:
+    bgp.local_as: 65103
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-leaf03:
+    bgp.local_as: 65103
+  roma-spine02:
+    bgp.local_as: 65200
+- roma-leaf04:
+    bgp.local_as: 65104
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-leaf04:
+    bgp.local_as: 65104
+  roma-spine02:
+    bgp.local_as: 65200
+- roma-exit01:
+    bgp.local_as: 65111
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-exit01:
+    bgp.local_as: 65111
+  roma-spine02:
+    bgp.local_as: 65200
+- roma-exit02:
+    bgp.local_as: 65112
+  roma-spine01:
+    bgp.local_as: 65200
+- roma-exit02:
+    bgp.local_as: 65112
+  roma-spine02:
+    bgp.local_as: 65200
+
+# Connection to DC edge
+- roma-exit01:
+    vrf: internet
+    bgp:
+      local_as: 65111
+      advertise: true
+  roma-dcedge01:
+    
+- roma-exit02:
+    bgp:
+      local_as: 65111
+      advertise: true
+    vrf: internet
+  roma-dcedge01:
+    
+# MLAG peerlinks
+- lag:
+    members:
+      - roma-leaf01: { ifname: eth3 }
+        roma-leaf02: { ifname: eth3 }
+    mlag.peergroup: true
+
+- lag:
+    members:
+      - roma-leaf03: { ifname: eth3 }
+        roma-leaf04: { ifname: eth3 }
+    mlag.peergroup: true
+
+- vlan: { access: red }
+  lag:
+    members:
+      - srv101: {}
+        roma-leaf01: {}
+      - srv101: {}
+        roma-leaf02: {}
+
+- vlan: { access: blue }
+  lag:
+    members:
+      - srv201: {}
+        roma-leaf03: {}
+      - srv201: {}
+        roma-leaf04: {}
+- vlan: { access: cyan }
+  lag:
+    members:
+      - srv102: {}
+        roma-leaf01: {}
+      - srv102: {}
+        roma-leaf02: {}
+- vlan: { access: cyan }
+  lag:
+    members:
+      - srv202: {}
+        roma-leaf03: {}
+      - srv202: {}
+        roma-leaf04: {}
+
+    
+ 


### PR DESCRIPTION
Added support for a leaf-spine topology with Arista using dual-stack, with IPv6 VXLAN i.e. IPv6 underlay. It also has a dc edge node in an internet vrf with route leaks between the evpn and the internet vrf. It utilizes MLAG for dual-attached hosts.